### PR TITLE
Added option to use custom preprocess middleware.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -18,7 +18,10 @@ function PeerServer(options) {
     timeout: 5000,
     key: 'peerjs',
     ip_limit: 5000,
-    concurrent_limit: 5000
+    concurrent_limit: 5000,
+    
+    // Empty middleware.
+    preprocess: function (req, res, next){ return next(); }
   }, options);
 
   util.debug = this._options.debug;
@@ -34,7 +37,7 @@ function PeerServer(options) {
 
   // Initialize HTTP routes. This is only used for the first few milliseconds
   // before a socket is opened for a Peer.
-  this._initializeHTTP();
+  this._initializeHTTP(this._options.preprocess);
   
   // Mark concurrent users per ip
   this._ips = {};
@@ -181,12 +184,15 @@ PeerServer.prototype._checkKey = function(key, ip, cb) {
 }
 
 /** Initialize HTTP server routes. */
-PeerServer.prototype._initializeHTTP = function() {
+PeerServer.prototype._initializeHTTP = function(preprocessMiddleware) {
   var self = this;
   
   this._app.use(restify.bodyParser({ mapParams: false }));
   this._app.use(restify.queryParser())
   this._app.use(util.allowCrossDomain);
+  
+  // Add custom middleware.
+  this._app.use(preprocessMiddleware);
 
   // Retrieve guaranteed random ID.
   this._app.get('/:key/id', function(req, res, next) {


### PR DESCRIPTION
Pass a middleware as `preprocess` option to `PeerServer` like so:

``` javascript
var PeerServer = require('peer').PeerServer;
var server = new PeerServer({
  port: 9000,
  preprocess: function (req, res, next) {
    // Do something with the request here,
    // Set some headers,
    // Blah..

    return next();
  }
});
```
