### PR TITLE
Add support for configurable server ip address

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -281,8 +281,13 @@ PeerServer.prototype._initializeHTTP = function() {
 
   this._app.post(this._options.path + ':key/:id/:token/leave', handle);
 
-  // Listen on user-specified port.
-  this._app.listen(this._options.port);
+  //Listen on user-specified port and ip address.
+  if (this._options.ip) {
+    this._app.listen(this._options.port, this._options.ip);
+  } else {
+    this._app.listen(this._options.port);
+  }
+
 };
 
 /** Saves a streaming response and takes care of timeouts and headers. */


### PR DESCRIPTION
This PR adds support for binding user-configured ip addresses to the server. This is required in some hosting clouds like OpenShift. We need to have a way to provide that to the application.

Example usage:

```
var server = new PeerServer({ port: serverPort, ip: ipAddress });
```

(check http://nodejs.org/api/net.html#net_server_listen_port_host_backlog_callback for more info about ip bindings in nodejs)
