### PR TITLE
Move this._app.listen call to listen method

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ var server = new PeerServer({
     certificate: fs.readFileSync('/path/to/your/ssl/certificate/here.crt')
   }
 });
+
+server.listen();
 ```
 
 ### Events

--- a/lib/server.js
+++ b/lib/server.js
@@ -280,9 +280,11 @@ PeerServer.prototype._initializeHTTP = function() {
   this._app.post(this._options.path + ':key/:id/:token/answer', handle);
 
   this._app.post(this._options.path + ':key/:id/:token/leave', handle);
+};
 
-  // Listen on user-specified port.
-  this._app.listen(this._options.port);
+PeerServer.prototype.listen = function(port, cb) {
+    // Listen on user-specified port.
+    this._app.listen(port || this._options.port, cb);
 };
 
 /** Saves a streaming response and takes care of timeouts and headers. */


### PR DESCRIPTION
Starting server after creating an object is usually not a good idea - there is no way to pass callback into `this._app.listen` and this blocks composing PeerServer with (at least) other restify applications.
