### PR TITLE
Update server.js

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -282,7 +282,7 @@ PeerServer.prototype._initializeHTTP = function() {
   this._app.post(this._options.path + ':key/:id/:token/leave', handle);
 
   // Listen on user-specified port.
-  this._app.listen(this._options.port);
+  this._app.listen(this._options.port, this._options.host);
 };
 
 /** Saves a streaming response and takes care of timeouts and headers. */


### PR DESCRIPTION
Expose the host option that exists at lower levels in the server API's to allow binding of a Peer server to a particular host.
