### PR TITLE
updates readme, adds 'bin' to init peer server and removes 'peer' from npm install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ or
 Install the library:
 
 ```bash
-$> npm install peer
+$> npm install
 ```
 
 Run the server:
 
 ```bash
-$> peerjs --port 9000 --key peerjs
+$> bin/peerjs --port 9000 --key peerjs
 ```
 
 Or, create a custom server:


### PR DESCRIPTION
just as an option if you want to avoid sudo npm install -g peer
