### PR TITLE
Fixes crash when user is not properly identified

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -199,6 +199,7 @@ app._initializeHTTP = function() {
     if (!self._clients[key] || !(client = self._clients[key][id])) {
       if (req.params.retry) {
         res.sendStatus(401);
+        return;
       } else {
         // Retry this request
         req.params.retry = true;


### PR DESCRIPTION
We have identified a crash when the user sends an invalid response. The if clause assignation makes client to be undefined; a 401 response is sent, but the handler keeps going and crashes on line 211. This small patch fixes this.