### PR TITLE
Added feature to choose the Access-Control-Allow-Origin header

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,8 @@ function ExpressPeerServer(server, options) {
     concurrent_limit: 5000,
     allow_discovery: false,
     proxied: false,
-    origin: '*'
+    origin: '*',
+    bindIp: null // default [::] and/or 0.0.0.0
   }, options);
 
   // Connected clients
@@ -84,11 +85,21 @@ function PeerServer(options, callback) {
   app.use(path, peerjs);
 
   if (callback) {
-    server.listen(port, function() {
-      callback(server);
-    });
+    if (options.bindIp == null) { // bindIp can be [::] and/or 0.0.0.0
+      server.listen(port, function() {
+        callback(server);
+      });
+    } else {
+      server.listen(port, options.bindIp, function() {
+        callback(server);
+      });
+    }
   } else {
-    server.listen(port);
+    if (options.bindIp == null) { // bindIp can be [::] and/or 0.0.0.0
+      server.listen(port);
+    } else {
+      server.listen(port, options.bindIp);
+    }
   }
 
   return peerjs;

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,8 @@ function ExpressPeerServer(server, options) {
     ip_limit: 5000,
     concurrent_limit: 5000,
     allow_discovery: false,
-    proxied: false
+    proxied: false,
+    origin: '*'
   }, options);
 
   // Connected clients
@@ -40,7 +41,7 @@ function ExpressPeerServer(server, options) {
 
     // Initialize HTTP routes. This is only used for the first few milliseconds
     // before a socket is opened for a Peer.
-    app._initializeHTTP();
+    app._initializeHTTP(options.origin);
     app._setCleanupIntervals();
     app._initializeWSS(server);
   });

--- a/lib/server.js
+++ b/lib/server.js
@@ -138,10 +138,10 @@ app._checkKey = function(key, ip, cb) {
 };
 
 /** Initialize HTTP server routes. */
-app._initializeHTTP = function() {
+app._initializeHTTP = function(origin) {
   var self = this;
 
-  this.use(cors());
+  this.use(cors({origin: origin}));
 
   this.get('/', function(req, res, next) {
     res.send(require('../app.json'));


### PR DESCRIPTION
It is necessary to reject unwanted requests. Anyone can view the html page source code. This is for safety.
