### PR TITLE
Add support for pinging

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -93,6 +93,8 @@ app._configureWS = function(socket, key, id, token) {
           dst: message.dst,
           payload: message.payload
         });
+      } else if (message.type === "PING") {
+          socket.send(JSON.stringify({type:"PONG", timestamp: Date.now()}));
       } else {
         util.prettyError('Message unrecognized');
       }


### PR DESCRIPTION
This has 2 uses, first this allows environments like Heroku (with 55 websocket timeout) to maintain long lived connections with help of continous pinging. Second use is an ability to determine exact latency.