### PR TITLE
Ignore heartbeat messages

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -93,6 +93,8 @@ app._configureWS = function(socket, key, id, token) {
           dst: message.dst,
           payload: message.payload
         });
+      } else if (message.type === 'HEARTBEAT') {
+        // Ignore - nothing needs doing here.
       } else {
         util.prettyError('Message unrecognized');
       }


### PR DESCRIPTION
Something like this would be great to avoid the "ERROR PeerServer:  Message unrecognized" messages when sending heartbeats as shown here: https://github.com/peers/peerjs/issues/227
