### PR TITLE
Signal other peers on new connected peer

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -47,6 +47,11 @@ app._initializeWSS = function(server) {
         }
       });
     } else {
+      for (peerid in self._clients[key]) {
+        if (self._clients[key].hasOwnProperty(peerid) && peerid !== id) {
+          self._clients[key][peerid].socket.send(JSON.stringify({ type: 'DISCOVERY', payload: { id: id } }));
+        }
+      }
       self._configureWS(socket, key, id, token);
     }
   });


### PR DESCRIPTION
In order for other clients be able to tell new peer connected this will send message to other connected peers with the current connecting peer id , so they will be able to listen to discovery event and call connect to this peer . 