### PR TITLE
fix#86: "Updating README.md: on express example, variable names clearer"

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,21 +78,28 @@ var ExpressPeerServer = require('peer').ExpressPeerServer;
 
 app.get('/', function(req, res, next) { res.send('Hello world!'); });
 
+// =======
+
 var server = app.listen(9000);
 
 var options = {
     debug: true
 }
 
-app.use('/api', ExpressPeerServer(server, options));
+var peerserver = ExpressPeerServer(server, options);
 
-// OR
+app.use('/api', peerserver);
+
+// == OR ==
 
 var server = require('http').createServer(app);
+var peerserver = ExpressPeerServer(server, options);
 
-app.use('/peerjs', ExpressPeerServer(server, options));
+app.use('/peerjs', peerserver);
 
 server.listen(9000);
+
+// ========
 ```
 
 ### Events
@@ -100,14 +107,14 @@ server.listen(9000);
 The `'connection'` event is emitted when a peer connects to the server.
 
 ```javascript
-server.on('connection', function(id) { ... });
+peerserver.on('connection', function(id) { ... });
 ```
 
 The `'disconnect'` event is emitted when a peer disconnects from the server or
 when the peer can no longer be reached.
 
 ```javascript
-server.on('disconnect', function(id) { ... });
+peerserver.on('disconnect', function(id) { ... });
 ```
 
 ## Problems?


### PR DESCRIPTION
I personally have been mislead by the express documentation, which uses bad variable names as example.
The previous documentation can be understood as : the 'on' event is caught by the express server (the "server" variable), not by the ExpressPeerServer.

This problem has already been raised:
 - https://stackoverflow.com/questions/34910958/how-to-get-list-of-connected-users-in-peerjs-server-with-express
 - https://github.com/peers/peerjs-server/issues/86

I just made the variable names more easily understandable :)