### PR TITLE
fix(messagesExpire): messageHandler null deconstruction

### DIFF
--- a/src/services/messagesExpire/index.js
+++ b/src/services/messagesExpire/index.js
@@ -20,7 +20,7 @@ module.exports = ({ realm, config }) => {
 
       for (const message of messages) {
         if (!seen[message.src]) {
-          messageHandler(null, {
+          messageHandler({ realm }, {
             type: MessageType.EXPIRE,
             src: message.dst,
             dst: message.src


### PR DESCRIPTION
messageExpires' pruneOutstanding() calls messageHandler's exported function with `null`, but `{ realm }` is required.

As a result, null desconstruction exception is thrown in basic usage scenarios.

**Changes proposed**: Replace `null` with `{ realm }`.