### PR TITLE
Add Gitpod support

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,9 @@
+image: gitpod/workspace-full
+
+tasks:
+  - init: npm i
+    command: npm start
+
+ports:
+  - port: 9000
+    onOpen: open-preview

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,3 @@
-image: gitpod/workspace-full
-
 tasks:
   - init: npm i
     command: npm start

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 PeerServer helps broker connections between PeerJS clients. Data is not proxied through the server.
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/peers/peerjs-server)
+
 ## [https://peerjs.com](https://peerjs.com)
 
 ### Run PeerServer


### PR DESCRIPTION
Adds a button in README to test the peerjs-server in a [Gitpod](https://www.gitpod.io) instance.