### PR TITLE
docs: specify path for express integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,18 +93,19 @@ const server = app.listen(9000);
 
 const options = {
     debug: true
+    path: '/peerjs'
 }
 
 const peerserver = ExpressPeerServer(server, options);
 
-app.use('/api', peerserver);
+app.use(options.path, peerserver);
 
 // == OR ==
 
 const server = require('http').createServer(app);
 const peerserver = ExpressPeerServer(server, options);
 
-app.use('/peerjs', peerserver);
+app.use(options.path, peerserver);
 
 server.listen(9000);
 


### PR DESCRIPTION
Due to the changes in #125, the path needs to be explicitly specified in the options for Express server integration, otherwise the WSS path and the express route may not be the same (e.g. the default "/myapp" vs. "/peerjs" based on current documentation example) resulting in a bad request error everytime a peer wants to connect to the broker server.

Fixes: #149 