### PR TITLE
doc: remove non exist debug option

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ app.get('/', (req, res, next) => res.send('Hello world!'));
 const server = app.listen(9000);
 
 const peerServer = ExpressPeerServer(server, {
-  debug: true,
   path: '/myapp'
 });
 


### PR DESCRIPTION
Remove `debug` option from the document as it's no longer part of the `IConfig` interface: https://github.com/peers/peerjs-server/blob/master/src/config/index.ts