### PR TITLE
Host option

### DIFF
--- a/bin/peerjs
+++ b/bin/peerjs
@@ -43,6 +43,11 @@ const opts = yargs
       demandOption: false,
       describe: "path to SSL certificate"
     },
+    host: {
+      demandOption: false,
+      alias: "H",
+      describe: "host"
+    },
     port: {
       demandOption: true,
       alias: "p",

--- a/dist/src/config/index.js
+++ b/dist/src/config/index.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const defaultConfig = {
+    host: "::",
     port: 9000,
     expire_timeout: 5000,
     alive_timeout: 60000,

--- a/dist/src/index.js
+++ b/dist/src/index.js
@@ -28,6 +28,7 @@ function PeerServer(options = {}, callback) {
     const app = express_1.default();
     const newOptions = Object.assign(Object.assign({}, config_1.default), options);
     const port = newOptions.port;
+    const host = newOptions.host;
     let server;
     if (newOptions.ssl && newOptions.ssl.key && newOptions.ssl.cert) {
         server = https_1.default.createServer(options.ssl, app);
@@ -39,7 +40,7 @@ function PeerServer(options = {}, callback) {
     }
     const peerjs = ExpressPeerServer(server, newOptions);
     app.use(peerjs);
-    server.listen(port, () => callback === null || callback === void 0 ? void 0 : callback(server));
+    server.listen(port, host, () => callback === null || callback === void 0 ? void 0 : callback(server));
     return peerjs;
 }
 exports.PeerServer = PeerServer;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,5 @@
 export interface IConfig {
+  readonly host: string;
   readonly port: number;
   readonly expire_timeout: number;
   readonly alive_timeout: number;
@@ -16,6 +17,7 @@ export interface IConfig {
 }
 
 const defaultConfig: IConfig = {
+  host: "::",
   port: 9000,
   expire_timeout: 5000,
   alive_timeout: 60000,

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ function PeerServer(options: Optional<IConfig> = {}, callback?: (server: Server)
   };
 
   const port = newOptions.port;
+  const host = newOptions.host;
 
   let server: Server;
 
@@ -57,7 +58,7 @@ function PeerServer(options: Optional<IConfig> = {}, callback?: (server: Server)
   const peerjs = ExpressPeerServer(server, newOptions);
   app.use(peerjs);
 
-  server.listen(port, () => callback?.(server));
+  server.listen(port, host, () => callback?.(server));
 
   return peerjs;
 }


### PR DESCRIPTION
Added host option (--host, -H) to listen only on localhost for proxy use, for example. I wasn't sure how to add a test, let me know if that's required. If this gets accepted, I can document the option in the README too. I could also show the default host value for the CLI although it wouldn't be DRY.