### PR TITLE
Allows SNICallback instead of hardcoded key/cert

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ function PeerServer(options: Optional<IConfig> = {}, callback?: (server: Server)
 
   let server: Server;
 
-  if (newOptions.ssl && newOptions.ssl.key && newOptions.ssl.cert) {
+  if ('ssl' in newOptions) {
     server = https.createServer(options.ssl!, app);
     // @ts-ignore
     delete newOptions.ssl;


### PR DESCRIPTION
This solves https://github.com/peers/peerjs-server/issues/209, allowing ssl options to use [SNICallback](https://nodejs.org/api/tls.html#tls_tls_createserver_options_secureconnectionlistener) instead of only a hardcoded key/cert pair.