### PR TITLE
Allows SNICallback instead of hardcoded key/cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,23 @@ const peerServer = PeerServer({
 });
 ```
 
+You can also pass any other [SSL options accepted by https.createServer](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistenerfrom), such as `SNICallback:
+
+```javascript
+const fs = require('fs');
+const { PeerServer } = require('peer');
+
+const peerServer = PeerServer({
+  port: 9000,
+  ssl: {
+    SNICallback: (servername, cb) => {
+        // your code here ....
+    }
+  }
+});
+```
+
+
 ## Running PeerServer behind a reverse proxy
 
 Make sure to set the `proxied` option, otherwise IP based limiting will fail.

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,8 +48,7 @@ function PeerServer(options: Optional<IConfig> = {}, callback?: (server: Server)
   let server: Server;
 
   const { ssl, ...restOptions } = newOptions;
-
-  if (ssl && ssl.key && ssl.cert) {
+  if (ssl && Object.keys(ssl).length) {
     server = https.createServer(ssl, app);
 
     newOptions = restOptions;


### PR DESCRIPTION
This updates the previous PR https://github.com/peers/peerjs-server/pull/219/ with the current code. It solves #209, allowing ssl options to use SNICallback instead of only a hardcoded key/cert pair. @afrokick I saw you accepted a few PRs this week, any chance this once can be included too? Thanks