### PR TITLE
docs: Add instructions for Google App Engine deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,67 @@ This will start a peerjs server on port 9000 exposed on port 9000 with key `peer
 
 Open your browser with http://localhost:9000/myapp It should returns JSON with name, description and website fields. http://localhost:9000/myapp/peerjs/id - should returns a random string (random client id)
 
+## Running in Google App Engine
+
+Google App Engine will create an HTTPS certificate for you automatically,
+making this by far the easiest way to deploy PeerJS in the Google Cloud
+Platform.
+
+1. Create a `package.json` file for GAE to read:
+
+```sh
+echo "{}" > package.json
+npm install express@latest peer@latest
+```
+
+2. Create an `app.yaml` file to configure the GAE application.
+
+```yaml
+runtime: nodejs
+
+# Flex environment required for WebSocket support, which is required for PeerJS.
+env: flex
+
+# Limit resources to one instance, one CPU, very little memory or disk.
+manual_scaling:
+  instances: 1
+resources:
+  cpu: 1
+  memory_gb: 0.5
+  disk_size_gb: 0.5
+```
+
+3. Create `server.js` (which node will run by default for the `start` script):
+
+```js
+const express = require('express');
+const { ExpressPeerServer } = require('peer');
+const app = express();
+
+app.enable('trust proxy');
+
+const PORT = process.env.PORT || 9000;
+const server = app.listen(PORT, () => {
+  console.log(`App listening on port ${PORT}`);
+  console.log('Press Ctrl+C to quit.');
+});
+
+const peerServer = ExpressPeerServer(server, {
+  path: '/'
+});
+
+app.use('/', peerServer);
+
+module.exports = app;
+```
+
+4. Deploy to an existing GAE project (assuming you are already logged in via
+`gcloud`), replacing `YOUR-PROJECT-ID-HERE` with your particular project ID:
+
+```sh
+gcloud app deploy --project=YOUR-PROJECT-ID-HERE --promote --quiet app.yaml
+```
+
 ## Privacy
 
 See [PRIVACY.md](https://github.com/peers/peerjs-server/blob/master/PRIVACY.md)


### PR DESCRIPTION
This adds instructions for Google App Engine deployment to the README.

I spent way too long trying to figure out how to use the official PeerJS Docker Hub images in Google Cloud Run before finding out that I couldn't directly use any Docker image that wasn't hosted in Google's Container Registry.

However, Google App Engine was much simpler to set up, and will create the HTTPS certificates for you, making it much simpler for PeerJS deployment than using Google Cloud Run containers or Google Compute Engine VMs.