### PR TITLE
Allowing to cast event to the rest of users

### DIFF
--- a/src/instance.ts
+++ b/src/instance.ts
@@ -42,7 +42,7 @@ export const createInstance = ({ app, server, options }: {
     config: customConfig
   });
 
-  wss.on("connection", (client: IClient) => {
+  wss.on("connection", (client: IClient, realm: IRealm) => {
     const messageQueue = realm.getMessageQueueById(client.getId());
 
     if (messageQueue) {
@@ -62,7 +62,7 @@ export const createInstance = ({ app, server, options }: {
     messageHandler.handle(client, message);
   });
 
-  wss.on("close", (client: IClient) => {
+  wss.on("close", (client: IClient, realm: IRealm) => {
     app.emit("disconnect", client);
   });
 


### PR DESCRIPTION
Allowing to access to realm  to share the events to the other connected users, let then know when a user connect or diconnect.
/*Implementation*/
peerServer.on('connection', (client, realm) => {
  if (!realm) return
  realm.getClientsIds().filter(a => a != client.id).forEach(peerId => {
    const message = { type: 'CONNECTED', peerId: client.id }
    realm.getClientById(peerId).getSocket().send(JSON.stringify(message))
  })
});

peerServer.on('disconnect', (client, realm) => {
  if (!realm) return
  realm.getClientsIds().filter(a => a != client.id).forEach(peerId => {
    const message = { type: 'DISCONNECTED', peerId: client.id }
    realm.getClientById(peerId).getSocket().send(JSON.stringify(message))
  })
});