### PR TITLE
fix: reduce unnecessary timeouts

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -25,7 +25,7 @@ const defaultConfig: IConfig = {
 	host: "::",
 	port: 9000,
 	expire_timeout: 5000,
-	alive_timeout: 60000,
+	alive_timeout: 90000,
 	key: "peerjs",
 	path: "/",
 	concurrent_limit: 5000,


### PR DESCRIPTION
Intensive throttling might result in heartbeats being sent only once a minute. For more information, see https://developer.chrome.com/blog/timer-throttling-in-chrome-88

I increased the timout of the public instance to **90s**. Some early results:
```SQL
SELECT 
    (filter(count(*), WHERE duration >= 85 AND duration <= 95) * 100) / filter(count(*), WHERE transactionType = 'Other') 
    AS 'Percentage of Requests in 85-95s Range'
FROM 
    Transaction 
WHERE 
    entityGuid = '....' 
    AND transactionType = 'Other' 
SINCE 
    1 day ago
```
| Interval | 60s Timout | 90s Timout |
|----------|------------|------------|
| 55s-65s  | 14.3%      | 4.55%      |
| 85s-95s  | 1.55%      | 7.53%      |

Approximately 12.75% (14.3% - 1.55%) of connections were terminated due to the timeout, while only 2.98% (7.53% - 4.55%) were actually dead.