### PR TITLE
refactor(dockerfile): remove redundant RUN instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM --platform=$BUILDPLATFORM docker.io/library/node:18.20.3 as build
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
-RUN mkdir /peer-server
 WORKDIR /peer-server
 COPY package.json package-lock.json ./
 RUN npm clean-install
@@ -10,7 +9,6 @@ RUN npm run build
 RUN npm run test
 
 FROM docker.io/library/node:18.20.3-alpine as production
-RUN mkdir /peer-server
 WORKDIR /peer-server
 COPY package.json package-lock.json ./
 RUN npm clean-install --omit=dev


### PR DESCRIPTION
Hi,

If the `WORKDIR` doesn't exist, it will be created even if it's not used in any subsequent Dockerfile instruction. [reference](https://docs.docker.com/reference/dockerfile/#workdir)