### PR TITLE
fix: send OPEN message when client reconnects

### DIFF
--- a/src/services/webSocketServer/index.ts
+++ b/src/services/webSocketServer/index.ts
@@ -100,6 +100,7 @@ export class WebSocketServer extends EventEmitter implements IWebSocketServer {
 				return;
 			}
 
+			socket.send(JSON.stringify({ type: MessageType.OPEN }));
 			this._configureWS(socket, client);
 			return;
 		}


### PR DESCRIPTION
There are cases where the `open` event does not fire when calling `peer.reconnect()` on the client.

If the socket with the client is connected after the client information has been removed from the server, there is no issue.

However, if a new socket is connected due to a reconnect before the client information is removed from the server, the `MessageType.OPEN` is not sent, causing the client to fail in receiving the `open` event.

Therefore, I modified it so that `MessageType.OPEN` is sent even when the client exists, when the `_onSocketConnection()` of the new socket is called.

For reference, there is an issue posted in the PeerJS repo by someone who experienced the same problem as I did. https://github.com/peers/peerjs/issues/1289